### PR TITLE
feat: Add complete Skills CRUD system

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,21 @@ model Education {
   updatedAt     DateTime @updatedAt
 }
 
+model Skill {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  name          String
+  category      String   // Frontend, Backend, Languages, Tools, etc.
+  iconType      String   // react-icon, custom, text
+  iconName      String?  // For React Icons (e.g., "FaReact", "SiTypescript")
+  iconUrl       String?  // For custom uploaded icons
+  color         String?  // For text-based skills or custom colors
+  proficiency   String?  // beginner, intermediate, advanced, expert
+  isActive      Boolean  @default(true)
+  displayOrder  Int      @default(0) // For ordering skills within category
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}
+
 enum UserRole {
   ADMIN
   VIEWER

--- a/src/app/admin/skills/page.tsx
+++ b/src/app/admin/skills/page.tsx
@@ -1,0 +1,536 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import {
+  useSkills,
+  useSkillForm,
+  Skill,
+  REACT_ICONS,
+  SKILL_CATEGORIES,
+  PROFICIENCY_LEVELS,
+} from "@/hooks/useSkills";
+import Input from "@/components/ui/Input";
+import ImageUpload from "@/components/ImageUpload";
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
+import {
+  PlusIcon,
+  PencilIcon,
+  EyeIcon,
+  TrashIcon,
+  CpuChipIcon,
+} from "@heroicons/react/24/outline";
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import Dialog from "@/components/ui/Dialog";
+import Button from "@/components/ui/Button";
+
+// Dynamic icon renderer
+const renderIcon = (skill: Skill) => {
+  if (skill.iconType === 'custom' && skill.iconUrl) {
+    return (
+      <Image
+        width={40}
+        height={40}
+        src={skill.iconUrl}
+        alt={skill.name}
+        className="w-10 h-10 object-contain"
+      />
+    );
+  }
+  
+  if (skill.iconType === 'text') {
+    return (
+      <div
+        className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-lg"
+        style={{ backgroundColor: skill.color || '#3B82F6' }}
+      >
+        {skill.name.charAt(0).toUpperCase()}
+      </div>
+    );
+  }
+  
+  if (skill.iconType === 'react-icon' && skill.iconName) {
+    // This would need to be dynamically imported in a real implementation
+    // For now, we'll show a placeholder
+    return (
+      <div className="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-lg flex items-center justify-center">
+        <CpuChipIcon className="w-6 h-6 text-gray-500" />
+      </div>
+    );
+  }
+  
+  return (
+    <div className="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-lg flex items-center justify-center">
+      <CpuChipIcon className="w-6 h-6 text-gray-500" />
+    </div>
+  );
+};
+
+export default function SkillsPage() {
+  const { skills, loading, createSkill, updateSkill, deleteSkill } = useSkills();
+  const {
+    formData,
+    setFormData,
+    errors,
+    handleFieldChange,
+    validateForm,
+    resetForm,
+  } = useSkillForm();
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isViewOpen, setIsViewOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [filterCategory, setFilterCategory] = useState<string>('All');
+
+  const handleCreateClick = () => {
+    resetForm();
+    setIsEditing(false);
+    setIsFormOpen(true);
+  };
+
+  const handleEditClick = (skill: Skill) => {
+    setFormData({
+      name: skill.name,
+      category: skill.category,
+      iconType: skill.iconType,
+      iconName: skill.iconName || '',
+      iconUrl: skill.iconUrl || '',
+      color: skill.color || '#3B82F6',
+      proficiency: skill.proficiency || 'intermediate',
+      isActive: skill.isActive,
+      displayOrder: skill.displayOrder,
+    });
+    setSelectedSkill(skill);
+    setIsEditing(true);
+    setIsFormOpen(true);
+  };
+
+  const handleViewClick = (skill: Skill) => {
+    setSelectedSkill(skill);
+    setIsViewOpen(true);
+  };
+
+  const handleDeleteClick = (skill: Skill) => {
+    setSelectedSkill(skill);
+    setIsDeleteOpen(true);
+  };
+
+  const handleFormSubmit = async () => {
+    if (!validateForm()) return;
+
+    const success =
+      isEditing && selectedSkill
+        ? await updateSkill(selectedSkill.id, formData)
+        : await createSkill(formData);
+
+    if (success) {
+      setIsFormOpen(false);
+      resetForm();
+      setSelectedSkill(null);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!selectedSkill) return;
+
+    const success = await deleteSkill(selectedSkill.id);
+    if (success) {
+      setIsDeleteOpen(false);
+      setSelectedSkill(null);
+    }
+  };
+
+  const handleImageUpload = (url: string) => {
+    handleFieldChange("iconUrl", url);
+  };
+
+  const filteredSkills = filterCategory === 'All' 
+    ? skills 
+    : skills.filter(skill => skill.category === filterCategory);
+
+  const categories = ['All', ...SKILL_CATEGORIES];
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Skills
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            Manage your technical skills and expertise
+          </p>
+        </div>
+        <Button
+          onClick={handleCreateClick}
+          className="flex items-center space-x-2"
+        >
+          <PlusIcon className="w-5 h-5" />
+          <span>Add Skill</span>
+        </Button>
+      </div>
+
+      {/* Category Filter */}
+      <div className="flex flex-wrap gap-2">
+        {categories.map((category) => (
+          <Button
+            key={category}
+            onClick={() => setFilterCategory(category)}
+            variant={filterCategory === category ? 'primary' : 'secondary'}
+            size="sm"
+          >
+            {category}
+          </Button>
+        ))}
+      </div>
+
+      {/* Skills Grid */}
+      {filteredSkills.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {filteredSkills.map((skill) => (
+            <div
+              key={skill.id}
+              className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4"
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex items-center space-x-3">
+                  {renderIcon(skill)}
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                      {skill.name}
+                    </h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      {skill.category}
+                    </p>
+                    {skill.proficiency && (
+                      <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+                        {skill.proficiency.charAt(0).toUpperCase() + skill.proficiency.slice(1)}
+                      </p>
+                    )}
+                    <div className="mt-2 flex items-center space-x-2">
+                      <span
+                        className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
+                          skill.isActive
+                            ? "bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300"
+                            : "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300"
+                        }`}
+                      >
+                        {skill.isActive ? "Active" : "Inactive"}
+                      </span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        Order: {skill.displayOrder}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center space-x-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleViewClick(skill)}
+                    className="p-1"
+                  >
+                    <EyeIcon className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleEditClick(skill)}
+                    className="p-1"
+                  >
+                    <PencilIcon className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleDeleteClick(skill)}
+                    className="p-1 text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-900/20"
+                  >
+                    <TrashIcon className="w-4 h-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12">
+          <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center">
+            <CpuChipIcon className="w-8 h-8 text-gray-400" />
+          </div>
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            No skills found
+          </h3>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            {filterCategory === 'All' 
+              ? 'Add your first skill to get started.'
+              : `No skills found in ${filterCategory} category.`
+            }
+          </p>
+          <Button onClick={handleCreateClick}>Add Skill</Button>
+        </div>
+      )}
+
+      {/* Form Dialog */}
+      <Dialog
+        isOpen={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        title={isEditing ? "Edit Skill" : "Add Skill"}
+        size="lg"
+      >
+        <div className="space-y-6">
+          {/* Name */}
+          <div>
+            <Input
+              label="Skill Name"
+              value={formData.name}
+              onChange={(e) => handleFieldChange("name", e.target.value)}
+              error={errors.name}
+              placeholder="Enter skill name"
+            />
+          </div>
+
+          {/* Category */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Category
+            </label>
+            <select
+              value={formData.category}
+              onChange={(e) => handleFieldChange("category", e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+            >
+              {SKILL_CATEGORIES.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+            {errors.category && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                {errors.category}
+              </p>
+            )}
+          </div>
+
+          {/* Icon Type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Icon Type
+            </label>
+            <div className="space-y-2">
+              {[
+                { value: 'react-icon', label: 'React Icon' },
+                { value: 'custom', label: 'Custom Icon' },
+                { value: 'text', label: 'Text Badge' },
+              ].map((type) => (
+                <label key={type.value} className="flex items-center">
+                  <input
+                    type="radio"
+                    name="iconType"
+                    value={type.value}
+                    checked={formData.iconType === type.value}
+                    onChange={(e) => handleFieldChange("iconType", e.target.value)}
+                    className="mr-2"
+                  />
+                  {type.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* React Icon Selection */}
+          {formData.iconType === 'react-icon' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                React Icon
+              </label>
+              <select
+                value={formData.iconName || ''}
+                onChange={(e) => handleFieldChange("iconName", e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              >
+                <option value="">Select an icon</option>
+                {REACT_ICONS.map((icon) => (
+                  <option key={icon.name} value={icon.name}>
+                    {icon.label}
+                  </option>
+                ))}
+              </select>
+              {errors.iconName && (
+                <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  {errors.iconName}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Custom Icon Upload */}
+          {formData.iconType === 'custom' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Custom Icon
+              </label>
+              <ImageUpload
+                image={formData.iconUrl || ''}
+                onUpload={handleImageUpload}
+                folder="skills"
+              />
+              {errors.iconUrl && (
+                <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  {errors.iconUrl}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Text Color */}
+          {formData.iconType === 'text' && (
+            <div>
+              <Input
+                label="Color"
+                type="color"
+                value={formData.color || '#3B82F6'}
+                onChange={(e) => handleFieldChange("color", e.target.value)}
+                error={errors.color}
+              />
+            </div>
+          )}
+
+          {/* Proficiency */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Proficiency Level
+            </label>
+            <select
+              value={formData.proficiency || 'intermediate'}
+              onChange={(e) => handleFieldChange("proficiency", e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+            >
+              {PROFICIENCY_LEVELS.map((level) => (
+                <option key={level.value} value={level.value}>
+                  {level.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Display Order */}
+          <div>
+            <Input
+              label="Display Order"
+              type="number"
+              value={formData.displayOrder}
+              onChange={(e) => handleFieldChange("displayOrder", parseInt(e.target.value) || 0)}
+              error={errors.displayOrder}
+              placeholder="0"
+            />
+          </div>
+
+          {/* Active Status */}
+          <div className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              id="isActive"
+              checked={formData.isActive}
+              onChange={(e) => handleFieldChange("isActive", e.target.checked)}
+              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+            />
+            <label
+              htmlFor="isActive"
+              className="text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Set as active (visible on website)
+            </label>
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+            <Button variant="secondary" onClick={() => setIsFormOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleFormSubmit}>
+              {isEditing ? "Update Skill" : "Add Skill"}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+
+      {/* View Dialog */}
+      <Dialog
+        isOpen={isViewOpen}
+        onClose={() => setIsViewOpen(false)}
+        title="View Skill"
+        size="md"
+      >
+        {selectedSkill && (
+          <div className="space-y-6">
+            <div className="flex items-center space-x-4">
+              {renderIcon(selectedSkill)}
+              <div>
+                <h3 className="text-xl font-semibold text-gray-900 dark:text-white">
+                  {selectedSkill.name}
+                </h3>
+                <p className="text-gray-600 dark:text-gray-400">
+                  {selectedSkill.category}
+                </p>
+                {selectedSkill.proficiency && (
+                  <p className="text-sm text-gray-500 dark:text-gray-500 mt-1">
+                    Proficiency: {selectedSkill.proficiency.charAt(0).toUpperCase() + selectedSkill.proficiency.slice(1)}
+                  </p>
+                )}
+                <span
+                  className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium mt-2 ${
+                    selectedSkill.isActive
+                      ? "bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300"
+                      : "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300"
+                  }`}
+                >
+                  {selectedSkill.isActive ? "Active" : "Inactive"}
+                </span>
+              </div>
+            </div>
+
+            <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+              <div className="text-sm text-gray-500 dark:text-gray-400">
+                <p>Icon Type: {selectedSkill.iconType}</p>
+                {selectedSkill.iconName && <p>Icon Name: {selectedSkill.iconName}</p>}
+                {selectedSkill.color && <p>Color: {selectedSkill.color}</p>}
+                <p>Display Order: {selectedSkill.displayOrder}</p>
+                <p>
+                  Created: {new Date(selectedSkill.createdAt).toLocaleDateString()}
+                </p>
+                <p>
+                  Updated: {new Date(selectedSkill.updatedAt).toLocaleDateString()}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <ConfirmDialog
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete Skill"
+        message={`Are you sure you want to delete the skill "${selectedSkill?.name}"? This action cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        variant="danger"
+      />
+    </div>
+  );
+}

--- a/src/app/api/skills/[id]/route.ts
+++ b/src/app/api/skills/[id]/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+
+// Validation schema
+const updateSkillSchema = z.object({
+  name: z.string().min(1, 'Skill name is required').optional(),
+  category: z.string().min(1, 'Category is required').optional(),
+  iconType: z.enum(['react-icon', 'custom', 'text']).optional(),
+  iconName: z.string().optional(),
+  iconUrl: z.string().url('Valid URL is required').optional().or(z.literal('')),
+  color: z.string().optional(),
+  proficiency: z.enum(['beginner', 'intermediate', 'advanced', 'expert']).optional(),
+  isActive: z.boolean().optional(),
+  displayOrder: z.number().int().min(0).optional(),
+})
+
+// GET /api/skills/[id] - Get specific skill
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+
+    const skill = await prisma.skill.findUnique({
+      where: { id },
+    })
+
+    if (!skill) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Skill not found',
+        },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: skill,
+    })
+  } catch (error) {
+    console.error('Error fetching skill:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to fetch skill',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+// PUT /api/skills/[id] - Update skill
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.user || session.user.role !== 'ADMIN') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Unauthorized',
+        },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const body = await request.json()
+    const validatedData = updateSkillSchema.parse(body)
+
+    const skill = await prisma.skill.update({
+      where: { id },
+      data: validatedData,
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: skill,
+    })
+  } catch (error) {
+    console.error('Error updating skill:', error)
+    
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Validation error',
+          details: error.issues,
+        },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to update skill',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+// DELETE /api/skills/[id] - Delete skill
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.user || session.user.role !== 'ADMIN') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Unauthorized',
+        },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+
+    const skill = await prisma.skill.delete({
+      where: { id },
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: skill,
+    })
+  } catch (error) {
+    console.error('Error deleting skill:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to delete skill',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+
+// Validation schemas
+const createSkillSchema = z.object({
+  name: z.string().min(1, 'Skill name is required'),
+  category: z.string().min(1, 'Category is required'),
+  iconType: z.enum(['react-icon', 'custom', 'text']),
+  iconName: z.string().optional(),
+  iconUrl: z.string().url('Valid URL is required').optional().or(z.literal('')),
+  color: z.string().optional(),
+  proficiency: z.enum(['beginner', 'intermediate', 'advanced', 'expert']).optional(),
+  isActive: z.boolean().default(true),
+  displayOrder: z.number().int().min(0).default(0),
+})
+
+const updateSkillSchema = createSkillSchema.partial()
+
+// GET /api/skills - Get all skills
+export async function GET() {
+  try {
+    const skills = await prisma.skill.findMany({
+      where: { isActive: true },
+      orderBy: [
+        { category: 'asc' },
+        { displayOrder: 'asc' },
+        { name: 'asc' }
+      ],
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: skills,
+    })
+  } catch (error) {
+    console.error('Error fetching skills:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to fetch skills',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+// POST /api/skills - Create new skill
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.user || session.user.role !== 'ADMIN') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Unauthorized',
+        },
+        { status: 401 }
+      )
+    }
+
+    const body = await request.json()
+    const validatedData = createSkillSchema.parse(body)
+
+    const skill = await prisma.skill.create({
+      data: validatedData,
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: skill,
+    })
+  } catch (error) {
+    console.error('Error creating skill:', error)
+    
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Validation error',
+          details: error.issues,
+        },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to create skill',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -4,15 +4,14 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import { FaReact, FaNodeJs, FaGitAlt, FaDocker, FaJava, FaPython, FaHtml5, FaCss3, FaGithub, FaJsSquare, FaDatabase, FaTerminal } from "react-icons/fa";
 import { SiMongodb, SiRedux, SiTailwindcss, SiTypescript, SiIntellijidea, SiMysql, SiFirebase, SiGraphql, SiPostgresql, SiPostman, SiPrisma, SiVite } from "react-icons/si";
+import { useSkills, Skill } from "@/hooks/useSkills";
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import Image from "next/image";
 
 type Category = "Frontend" | "Backend" | "Languages" | "Tools";
 
-interface Skill {
-  name: string;
-  icon: JSX.Element;
-}
-
-const skillCategories: Record<Category, Skill[]> = {
+// Fallback skills data
+const fallbackSkills: Record<Category, { name: string; icon: JSX.Element }[]> = {
   Frontend: [
     { name: "React.js", icon: <FaReact size={40} /> },
     { name: "Tailwind CSS", icon: <SiTailwindcss size={40} /> },
@@ -49,8 +48,101 @@ const skillCategories: Record<Category, Skill[]> = {
   ],
 };
 
+// Icon mapping for dynamic rendering
+const iconMap: Record<string, JSX.Element> = {
+  'FaReact': <FaReact size={40} />,
+  'SiTailwindcss': <SiTailwindcss size={40} />,
+  'FaHtml5': <FaHtml5 size={40} />,
+  'FaCss3': <FaCss3 size={40} />,
+  'FaJsSquare': <FaJsSquare size={40} />,
+  'SiTypescript': <SiTypescript size={40} />,
+  'SiRedux': <SiRedux size={40} />,
+  'SiVite': <SiVite size={40} />,
+  'FaNodeJs': <FaNodeJs size={40} />,
+  'SiMongodb': <SiMongodb size={40} />,
+  'SiMysql': <SiMysql size={40} />,
+  'SiPostgresql': <SiPostgresql size={40} />,
+  'SiFirebase': <SiFirebase size={40} />,
+  'FaDatabase': <FaDatabase size={40} />,
+  'SiPrisma': <SiPrisma size={40} />,
+  'FaPython': <FaPython size={40} />,
+  'FaJava': <FaJava size={40} />,
+  'FaGitAlt': <FaGitAlt size={40} />,
+  'FaGithub': <FaGithub size={40} />,
+  'FaDocker': <FaDocker size={40} />,
+  'SiIntellijidea': <SiIntellijidea size={40} />,
+  'SiPostman': <SiPostman size={40} />,
+  'FaTerminal': <FaTerminal size={40} />,
+};
+
+// Helper function to render skill icon
+const renderSkillIcon = (skill: Skill) => {
+  if (skill.iconType === 'custom' && skill.iconUrl) {
+    return (
+      <Image
+        src={skill.iconUrl}
+        alt={skill.name}
+        width={40}
+        height={40}
+        className="w-10 h-10 object-contain"
+      />
+    );
+  }
+  
+  if (skill.iconType === 'text') {
+    return (
+      <div
+        className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-lg"
+        style={{ backgroundColor: skill.color || '#3B82F6' }}
+      >
+        {skill.name.charAt(0).toUpperCase()}
+      </div>
+    );
+  }
+  
+  if (skill.iconType === 'react-icon' && skill.iconName) {
+    return iconMap[skill.iconName] || <FaReact size={40} />;
+  }
+  
+  return <FaReact size={40} />;
+};
+
 export default function Skills() {
+  const { skills, loading, error } = useSkills();
   const [activeCategory, setActiveCategory] = useState<Category>("Frontend");
+
+  // Group skills by category
+  const skillsByCategory = skills.reduce((acc, skill) => {
+    const category = skill.category as Category;
+    if (!acc[category]) {
+      acc[category] = [];
+    }
+    acc[category].push(skill);
+    return acc;
+  }, {} as Record<Category, Skill[]>);
+
+  // Use dynamic skills or fallback
+  const skillCategories = Object.keys(skillsByCategory).length > 0 
+    ? skillsByCategory 
+    : fallbackSkills;
+
+  if (loading) {
+    return (
+      <section
+        id="skills"
+        className="min-h-screen flex flex-col items-center justify-center bg-background p-6"
+      >
+        <div className="flex flex-col items-center space-y-4">
+          <LoadingSpinner size="lg" />
+          <p className="text-foreground/70">Loading skills...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    console.error('Error loading skills:', error);
+  }
 
   return (
     <section
@@ -93,22 +185,33 @@ export default function Skills() {
           transition={{ duration: 0.5 }}
           className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-8"
         >
-          {skillCategories[activeCategory].map((skill, index) => (
-            <motion.div
-              key={skill.name}
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
-              className="flex flex-col items-center justify-center p-6 bg-card text-card-foreground rounded-xl shadow-md hover:shadow-xl hover:-translate-y-2 transition-all duration-300 border border-border"
-            >
-              <div className="text-primary mb-3">
-                {skill.icon}
-              </div>
-              <span className="text-md font-medium text-foreground text-center">
-                {skill.name}
-              </span>
-            </motion.div>
-          ))}
+          {skillCategories[activeCategory]?.map((skill, index) => {
+            const isDynamicSkill = 'id' in skill;
+            const skillName = isDynamicSkill ? skill.name : skill.name;
+            const skillIcon = isDynamicSkill ? renderSkillIcon(skill as Skill) : skill.icon;
+            
+            return (
+              <motion.div
+                key={isDynamicSkill ? (skill as Skill).id : skillName}
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.5, delay: index * 0.1 }}
+                className="flex flex-col items-center justify-center p-6 bg-card text-card-foreground rounded-xl shadow-md hover:shadow-xl hover:-translate-y-2 transition-all duration-300 border border-border"
+              >
+                <div className="text-primary mb-3">
+                  {skillIcon}
+                </div>
+                <span className="text-md font-medium text-foreground text-center">
+                  {skillName}
+                </span>
+                {isDynamicSkill && (skill as Skill).proficiency && (
+                  <span className="text-xs text-foreground/60 mt-1">
+                    {(skill as Skill).proficiency!.charAt(0).toUpperCase() + (skill as Skill).proficiency!.slice(1)}
+                  </span>
+                )}
+              </motion.div>
+            );
+          })}
         </motion.div>
       </div>
     </section>

--- a/src/components/admin/Sidebar.tsx
+++ b/src/components/admin/Sidebar.tsx
@@ -13,7 +13,8 @@ import {
   UserIcon,
   Cog6ToothIcon,
   UserCircleIcon,
-  AcademicCapIcon
+  AcademicCapIcon,
+  CpuChipIcon
 } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/utils'
 import Tooltip from '@/components/ui/Tooltip'
@@ -32,6 +33,7 @@ const navigation = [
   { name: 'Honors', href: '/admin/honors', icon: TrophyIcon },
   { name: 'Experience', href: '/admin/experience', icon: BriefcaseIcon },
   { name: 'Education', href: '/admin/education', icon: AcademicCapIcon },
+  { name: 'Skills', href: '/admin/skills', icon: CpuChipIcon },
   { name: 'CVs', href: '/admin/cvs', icon: DocumentTextIcon },
   { name: 'Public Profile', href: '/admin/public-profile', icon: UserCircleIcon },
   { name: 'Profile', href: '/admin/profile', icon: Cog6ToothIcon },

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -1,0 +1,327 @@
+"use client"
+
+import { useState, useEffect } from 'react'
+import { skillsApi } from '@/lib/api'
+import { TOAST_MESSAGES } from '@/lib/constants'
+import { toast } from 'react-hot-toast'
+
+export interface Skill {
+  id: string
+  name: string
+  category: string
+  iconType: 'react-icon' | 'custom' | 'text'
+  iconName?: string
+  iconUrl?: string
+  color?: string
+  proficiency?: 'beginner' | 'intermediate' | 'advanced' | 'expert'
+  isActive: boolean
+  displayOrder: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SkillFormData {
+  name: string
+  category: string
+  iconType: 'react-icon' | 'custom' | 'text'
+  iconName?: string
+  iconUrl?: string
+  color?: string
+  proficiency?: 'beginner' | 'intermediate' | 'advanced' | 'expert'
+  isActive: boolean
+  displayOrder: number
+}
+
+export const useSkills = () => {
+  const [skills, setSkills] = useState<Skill[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch all skills
+  const fetchSkills = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await skillsApi.getAll()
+      
+      if (response.success) {
+        setSkills(response.data)
+      } else {
+        setError(response.error || 'Failed to fetch skills')
+      }
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.error || 'Failed to fetch skills'
+      setError(errorMessage)
+      toast.error(errorMessage)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Create new skill
+  const createSkill = async (data: SkillFormData): Promise<boolean> => {
+    try {
+      setLoading(true)
+      setError(null)
+      
+      const response = await skillsApi.create(data)
+      
+      if (response.success) {
+        setSkills(prev => [...prev, response.data])
+        toast.success(TOAST_MESSAGES.SKILLS.CREATE_SUCCESS)
+        return true
+      } else {
+        const errorMessage = response.error || 'Failed to create skill'
+        setError(errorMessage)
+        toast.error(errorMessage)
+        return false
+      }
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.error || 'Failed to create skill'
+      setError(errorMessage)
+      toast.error(errorMessage)
+      return false
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Update skill
+  const updateSkill = async (id: string, data: Partial<SkillFormData>): Promise<boolean> => {
+    try {
+      setLoading(true)
+      setError(null)
+      
+      const response = await skillsApi.update(id, data)
+      
+      if (response.success) {
+        setSkills(prev => prev.map(skill => skill.id === id ? response.data : skill))
+        toast.success(TOAST_MESSAGES.SKILLS.UPDATE_SUCCESS)
+        return true
+      } else {
+        const errorMessage = response.error || 'Failed to update skill'
+        setError(errorMessage)
+        toast.error(errorMessage)
+        return false
+      }
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.error || 'Failed to update skill'
+      setError(errorMessage)
+      toast.error(errorMessage)
+      return false
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Delete skill
+  const deleteSkill = async (id: string): Promise<boolean> => {
+    try {
+      setLoading(true)
+      setError(null)
+      
+      const response = await skillsApi.delete(id)
+      
+      if (response.success) {
+        setSkills(prev => prev.filter(skill => skill.id !== id))
+        toast.success(TOAST_MESSAGES.SKILLS.DELETE_SUCCESS)
+        return true
+      } else {
+        const errorMessage = response.error || 'Failed to delete skill'
+        setError(errorMessage)
+        toast.error(errorMessage)
+        return false
+      }
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.error || 'Failed to delete skill'
+      setError(errorMessage)
+      toast.error(errorMessage)
+      return false
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Load skills on mount
+  useEffect(() => {
+    fetchSkills()
+  }, [])
+
+  return {
+    skills,
+    loading,
+    error,
+    fetchSkills,
+    createSkill,
+    updateSkill,
+    deleteSkill,
+  }
+}
+
+// Hook for managing skill form
+export const useSkillForm = (initialData?: Partial<SkillFormData>) => {
+  const [formData, setFormData] = useState<SkillFormData>({
+    name: '',
+    category: 'Frontend',
+    iconType: 'react-icon',
+    iconName: '',
+    iconUrl: '',
+    color: '#3B82F6',
+    proficiency: 'intermediate',
+    isActive: true,
+    displayOrder: 0,
+    ...initialData,
+  })
+
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const handleFieldChange = (field: keyof SkillFormData, value: any) => {
+    setFormData(prev => ({ ...prev, [field]: value }))
+    
+    // Clear error when user starts typing
+    if (errors[field]) {
+      setErrors(prev => ({ ...prev, [field]: '' }))
+    }
+  }
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {}
+
+    if (!formData.name.trim()) {
+      newErrors.name = 'Skill name is required'
+    }
+
+    if (!formData.category.trim()) {
+      newErrors.category = 'Category is required'
+    }
+
+    if (formData.iconType === 'react-icon' && !formData.iconName?.trim()) {
+      newErrors.iconName = 'Icon name is required for React Icons'
+    }
+
+    if (formData.iconType === 'custom' && !formData.iconUrl?.trim()) {
+      newErrors.iconUrl = 'Icon URL is required for custom icons'
+    }
+
+    if (formData.iconType === 'text' && !formData.color?.trim()) {
+      newErrors.color = 'Color is required for text-based skills'
+    }
+
+    if (formData.displayOrder < 0) {
+      newErrors.displayOrder = 'Display order must be 0 or greater'
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const resetForm = () => {
+    setFormData({
+      name: '',
+      category: 'Frontend',
+      iconType: 'react-icon',
+      iconName: '',
+      iconUrl: '',
+      color: '#3B82F6',
+      proficiency: 'intermediate',
+      isActive: true,
+      displayOrder: 0,
+    })
+    setErrors({})
+  }
+
+  return {
+    formData,
+    setFormData,
+    errors,
+    handleFieldChange,
+    validateForm,
+    resetForm,
+  }
+}
+
+// Available React Icons for skills
+export const REACT_ICONS = [
+  // Frontend
+  { name: 'FaReact', label: 'React' },
+  { name: 'FaHtml5', label: 'HTML5' },
+  { name: 'FaCss3', label: 'CSS3' },
+  { name: 'FaJsSquare', label: 'JavaScript' },
+  { name: 'SiTypescript', label: 'TypeScript' },
+  { name: 'SiTailwindcss', label: 'Tailwind CSS' },
+  { name: 'SiRedux', label: 'Redux' },
+  { name: 'SiVite', label: 'Vite' },
+  { name: 'SiNextdotjs', label: 'Next.js' },
+  { name: 'SiVuedotjs', label: 'Vue.js' },
+  { name: 'SiAngular', label: 'Angular' },
+  { name: 'SiSvelte', label: 'Svelte' },
+  
+  // Backend
+  { name: 'FaNodeJs', label: 'Node.js' },
+  { name: 'SiExpress', label: 'Express.js' },
+  { name: 'SiNestjs', label: 'NestJS' },
+  { name: 'SiFastify', label: 'Fastify' },
+  { name: 'SiDjango', label: 'Django' },
+  { name: 'SiFlask', label: 'Flask' },
+  { name: 'SiSpring', label: 'Spring' },
+  { name: 'SiLaravel', label: 'Laravel' },
+  { name: 'SiRubyonrails', label: 'Ruby on Rails' },
+  
+  // Databases
+  { name: 'SiMongodb', label: 'MongoDB' },
+  { name: 'SiMysql', label: 'MySQL' },
+  { name: 'SiPostgresql', label: 'PostgreSQL' },
+  { name: 'SiRedis', label: 'Redis' },
+  { name: 'SiFirebase', label: 'Firebase' },
+  { name: 'SiSupabase', label: 'Supabase' },
+  
+  // Tools
+  { name: 'FaGitAlt', label: 'Git' },
+  { name: 'FaGithub', label: 'GitHub' },
+  { name: 'FaDocker', label: 'Docker' },
+  { name: 'SiKubernetes', label: 'Kubernetes' },
+  { name: 'SiPostman', label: 'Postman' },
+  { name: 'SiInsomnia', label: 'Insomnia' },
+  { name: 'SiFigma', label: 'Figma' },
+  { name: 'SiAdobephotoshop', label: 'Photoshop' },
+  { name: 'SiAdobexd', label: 'Adobe XD' },
+  { name: 'SiVisualstudiocode', label: 'VS Code' },
+  { name: 'SiIntellijidea', label: 'IntelliJ IDEA' },
+  { name: 'SiWebstorm', label: 'WebStorm' },
+  { name: 'SiSublimetext', label: 'Sublime Text' },
+  
+  // Languages
+  { name: 'FaPython', label: 'Python' },
+  { name: 'FaJava', label: 'Java' },
+  { name: 'SiCplusplus', label: 'C++' },
+  { name: 'SiCsharp', label: 'C#' },
+  { name: 'SiGo', label: 'Go' },
+  { name: 'SiRust', label: 'Rust' },
+  { name: 'SiPhp', label: 'PHP' },
+  { name: 'SiRuby', label: 'Ruby' },
+  { name: 'SiSwift', label: 'Swift' },
+  { name: 'SiKotlin', label: 'Kotlin' },
+  { name: 'SiScala', label: 'Scala' },
+  { name: 'SiR', label: 'R' },
+]
+
+// Available categories
+export const SKILL_CATEGORIES = [
+  'Frontend',
+  'Backend', 
+  'Languages',
+  'Tools',
+  'Database',
+  'Mobile',
+  'DevOps',
+  'Design',
+  'Other'
+]
+
+// Proficiency levels
+export const PROFICIENCY_LEVELS = [
+  { value: 'beginner', label: 'Beginner' },
+  { value: 'intermediate', label: 'Intermediate' },
+  { value: 'advanced', label: 'Advanced' },
+  { value: 'expert', label: 'Expert' },
+]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -148,6 +148,19 @@ export const educationApi = {
   delete: (id: string) => api.delete(API_ENDPOINTS.EDUCATION.BY_ID(id)),
 }
 
+// Skills API
+export const skillsApi = {
+  getAll: () => api.get(API_ENDPOINTS.SKILLS.BASE),
+  
+  getById: (id: string) => api.get(API_ENDPOINTS.SKILLS.BY_ID(id)),
+  
+  create: (data: any) => api.post(API_ENDPOINTS.SKILLS.BASE, data),
+  
+  update: (id: string, data: any) => api.put(API_ENDPOINTS.SKILLS.BY_ID(id), data),
+  
+  delete: (id: string) => api.delete(API_ENDPOINTS.SKILLS.BY_ID(id)),
+}
+
 // Upload API
 export const uploadApi = {
   uploadImage: (file: File, folder: string = 'portfolio') => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -37,6 +37,11 @@ export const API_ENDPOINTS = {
     BASE: '/api/education',
     BY_ID: (id: string) => `/api/education/${id}`,
   },
+  // Skills
+  SKILLS: {
+    BASE: '/api/skills',
+    BY_ID: (id: string) => `/api/skills/${id}`,
+  },
   // Auth
   AUTH: {
     LOGIN: '/api/auth/signin',
@@ -110,6 +115,15 @@ export const TOAST_MESSAGES = {
     UPDATE_ERROR: 'Failed to update education entry',
     DELETE_SUCCESS: 'Education entry deleted successfully!',
     DELETE_ERROR: 'Failed to delete education entry',
+  },
+  SKILLS: {
+    FETCH_ERROR: 'Failed to fetch skills',
+    CREATE_SUCCESS: 'Skill created successfully!',
+    CREATE_ERROR: 'Failed to create skill',
+    UPDATE_SUCCESS: 'Skill updated successfully!',
+    UPDATE_ERROR: 'Failed to update skill',
+    DELETE_SUCCESS: 'Skill deleted successfully!',
+    DELETE_ERROR: 'Failed to delete skill',
   },
   GENERAL: {
     NETWORK_ERROR: 'Network error. Please check your connection.',


### PR DESCRIPTION
- Add Skill model to Prisma schema with iconType, iconName, iconUrl, color, proficiency fields
- Create API routes for skills CRUD operations (/api/skills)
- Add skillsApi methods to lib/api.ts
- Create useSkills hook with form management and validation
- Add Skills admin page with full CRUD interface
- Update Skills component to use dynamic data with fallback
- Support React Icons, custom icons, and text-based skill badges
- Add Skills to admin sidebar navigation
- Include comprehensive icon mapping for common technologies
- Add proficiency levels and category filtering
- Replace img tags with Next.js Image components